### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+# Automatically build the project and run any configured tests for every push
+# and submitted pull request. This can help catch issues that only occur on
+# certain platforms or Java versions, and provides a first line of defence
+# against bad commits.
+
+name: build
+on: [pull_request, push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        # Run on both Linux and Windows
+        os: [ubuntu-20.04, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+      - name: validate gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: setup jdk
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 8.0
+      - name: build
+        run: ./gradlew build
+      - name: capture build artifacts
+        if: ${{ runner.os == 'Linux' }} # Only upload artifacts built from Java 1.8 on Linux
+        uses: actions/upload-artifact@v2
+        with:
+          name: Artifacts
+          path: build/libs/


### PR DESCRIPTION
Similar to upstream, but remove builds on Java 11 and 16 because they
aren't reliable in cursed-fabric. Upload artifacts from the Linux
build.

Modern Fabric example mods does it already, why not us? This only runs builds on Java 8, but it still runs a build on Windows. Apparently this is good practice, since upstream does it. Convenient for users too.